### PR TITLE
libusbx support extended

### DIFF
--- a/usb/backend/libusb0.py
+++ b/usb/backend/libusb0.py
@@ -183,7 +183,8 @@ class _DeviceDescriptor:
         self.bNumConfigurations = desc.bNumConfigurations
         self.address = dev.devnum
         self.bus = dev.bus[0].location
-
+        
+        self.port_number = None
 _lib = None
 
 def _load_library():

--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -390,6 +390,9 @@ def _setup_prototypes(lib):
     lib.libusb_get_device_address.argtypes = [c_void_p]
     lib.libusb_get_device_address.restype = c_uint8
 
+	# uint8_t libusb_get_port_number(libusb_device *dev)
+    lib.libusb_get_port_number.argtypes = [c_void_p]
+    lib.libusb_get_port_number.restype = c_uint8
 
 
 # check a libusb function call
@@ -461,7 +464,9 @@ class _LibUSB(usb.backend.IBackend):
         dev_desc = _libusb_device_descriptor()
         _check(_lib.libusb_get_device_descriptor(dev.devid, byref(dev_desc)))
         dev_desc.bus = _lib.libusb_get_bus_number(dev.devid)
-        dev_desc.address = _lib.libusb_get_device_address(dev.devid) 
+        dev_desc.address = _lib.libusb_get_device_address(dev.devid)
+        dev_desc.port_number = _lib.libusb_get_port_number(dev.devid)
+
         return dev_desc
 
     @methodtrace(_logger)

--- a/usb/backend/openusb.py
+++ b/usb/backend/openusb.py
@@ -536,6 +536,7 @@ class _OpenUSB(usb.backend.IBackend):
                                               byref(desc)))
         desc.bus = None
         desc.address = None
+        desc.port_number = None
         return desc
 
     @methodtrace(_logger)

--- a/usb/core.py
+++ b/usb/core.py
@@ -528,7 +528,8 @@ class Device(object):
                     'iSerialNumber',
                     'bNumConfigurations',
                     'address',
-                    'bus'
+                    'bus',
+                    'port_number'
                 )
             )
 
@@ -542,6 +543,11 @@ class Device(object):
         else:
             self.address = None
 
+        if desc.port_number is not None:
+            self.port_number = int(desc.port_number)
+        else:
+            self.port_number = None
+            
     def set_configuration(self, configuration = None):
         r"""Set the active configuration.
         


### PR DESCRIPTION
Support for port number retrieval of an usb device connected to an usb hub via an specific usb port.
If you access desc.port_number via other libs like openusb, you get None.
