### PR TITLE
Match **args before custom_match in usb.core.find()

### DIFF
--- a/usb/core.py
+++ b/usb/core.py
@@ -836,8 +836,7 @@ def find(find_all=False, backend = None, custom_match = None, **args):
     def device_iter(k, v):
         for dev in backend.enumerate_devices():
             d = Device(dev, backend)
-            if (custom_match is None or custom_match(d)) and \
-                _interop._reduce(
+            if  _interop._reduce(
                         lambda a, b: a and b,
                         map(
                             operator.eq,
@@ -845,7 +844,7 @@ def find(find_all=False, backend = None, custom_match = None, **args):
                             map(lambda i: getattr(d, i), k)
                         ),
                         True
-                    ):
+                    ) and (custom_match is None or custom_match(d)):
                 yield d
 
     if backend is None:


### PR DESCRIPTION
Previous the custom_match was tested before any **args matching, this
resulted in unwanted behavior when the custom_match had to perform
a action towards the usb device that required permission that was not
necessary available for all usb devices.

Example use case where this is needed, want to match on idVendor and iManufacturer. To get iManufacturer device needs permission to use the device, under a normal linux system a non-root user dont have acess to all usb devices, but by limiting the custom_match critera to only devices matching the **args critera this problem is solved.

example program needing this commit to work as non-root:
import usb
import usb.util

def match_manufacturer(dev):
    if usb.util.get_string(dev,126, dev.iManufacturer) == "pthread.se":
        return True
    return False

dev = usb.core.find(idVendor=0x16c0, custom_match=match_manufacturer)
dev.set_configuration()
print usb.util.get_string(dev,126, dev.iManufacturer)
