### PR TITLE
Legacy USB Configuration issue

### DIFF
--- a/usb/legacy.py
+++ b/usb/legacy.py
@@ -254,7 +254,7 @@ class DeviceHandle(object):
         Arguments:
             configuration: a configuration value or a Configuration object.
         """
-        self.dev.set_configuration(configuration)
+        self.dev.set_configuration(configuration.value)
 
     def setAltInterface(self, alternate):
         r"""Sets the active alternate setting of the current interface.


### PR DESCRIPTION
Changed usb.core to extract Configuration details from a usb.legacy.Configuration object. This was causing an error initialising a USB NFC reader based on the PN531 chipset.
