### PR TITLE
Fix for issue #14 (Windows support on CPython 3.3)

### DIFF
--- a/usb/backend/libusb0.py
+++ b/usb/backend/libusb0.py
@@ -191,6 +191,10 @@ def _load_library():
     if sys.platform != 'cygwin':
         candidates = ('usb-0.1', 'usb', 'libusb0')
         for candidate in candidates:
+            # Workaround for CPython 3.3 issue#16283 / pyusb #14
+            if sys.platform == 'win32':
+                candidate = candidate + '.dll'
+
             libname = ctypes.util.find_library(candidate)
             if libname is not None: break
     else:

--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -182,6 +182,9 @@ def _load_library():
     if sys.platform != 'cygwin':
         candidates = ('usb-1.0', 'libusb-1.0', 'usb')
         for candidate in candidates:
+            if sys.platform == 'win32':
+                candidate = candidate + '.dll'
+
             libname = ctypes.util.find_library(candidate)
             if libname is not None: break
     else:

--- a/usb/backend/openusb.py
+++ b/usb/backend/openusb.py
@@ -32,6 +32,7 @@ import usb.util
 from usb._debug import methodtrace
 import logging
 import errno
+import sys
 
 __author__ = 'Wander Lairson Costa'
 
@@ -243,7 +244,12 @@ _lib = None
 _ctx = None
 
 def _load_library():
-    libname = ctypes.util.find_library('openusb')
+    candidate = 'openusb'
+    # Workaround for CPython 3.3 issue#16283 / pyusb #14
+    if sys.platform == 'win32':
+        candidate = candidate + '.dll'
+
+    libname = ctypes.util.find_library(candidate)
     if libname is None:
         raise OSError('USB library could not be found')
     return CDLL(libname)


### PR DESCRIPTION
I bumped into CPython 3.3 issue #16283 on Win64 today.  This patch is a workaround until CPython can be fixed, and addresses pyusb issue #14.  

I've tested with libusb0 on Windows 7 64-bit, CPython 3.3 64-bit and 2.7.3. Unfortunately I don't have time to setup openusb/libusb1 on Windows right now.  

Thanks for all the great work you've done with pyusb; I've used it extensively at work.
