### PR TITLE
Add `readinto` function that reads into a pre-created buffer

### DIFF
--- a/usb/backend/libusb0.py
+++ b/usb/backend/libusb0.py
@@ -482,11 +482,12 @@ class _LibUSB(usb.backend.IBackend):
                             data, timeout)
 
     @methodtrace(_logger)
-    def bulk_read(self, dev_handle, ep, intf, size, timeout):
+    def bulk_read(self, dev_handle, ep, intf, data, size, timeout):
         return self.__read(_lib.usb_bulk_read,
                            dev_handle,
                            ep,
                            intf,
+                           data,
                            size,
                            timeout)
 
@@ -500,11 +501,12 @@ class _LibUSB(usb.backend.IBackend):
                             timeout)
 
     @methodtrace(_logger)
-    def intr_read(self, dev_handle, ep, intf, size, timeout):
+    def intr_read(self, dev_handle, ep, intf, data, size, timeout):
         return self.__read(_lib.usb_interrupt_read,
                            dev_handle,
                            ep,
                            intf,
+                           data,
                            size,
                            timeout)
 
@@ -564,8 +566,10 @@ class _LibUSB(usb.backend.IBackend):
                         timeout
                     )))
 
-    def __read(self, fn, dev_handle, ep, intf, size, timeout):
-        data = _interop.as_array((0,) * size)
+    def __read(self, fn, dev_handle, ep, intf, data, size, timeout):
+        read_into = (data != None)
+        if not read_into:
+            data = _interop.as_array((0,) * size)
         address, length = data.buffer_info()
         length *= data.itemsize
         ret = int(_check(fn(
@@ -575,7 +579,10 @@ class _LibUSB(usb.backend.IBackend):
                     length,
                     timeout
                 )))
-        return data[:ret]
+        if read_into:
+            return ret
+        else:
+            return data[:ret]
 
 def get_backend():
     global _lib


### PR DESCRIPTION
I would like to propose a function analogous to [pySerial's `readinto`](http://pyserial.sourceforge.net/pyserial_api.html#serial.Serial.readinto) function.

Currently, the `read` function creates a new buffer of the requested size and fills it with data. This buffer is created at every call to this function, which is not optimal. To provide more flexibility, a `readinto` function could take a buffer, created by the user, as an argument and fill that one instead. Instead of returning the buffer, the function returns the number of bytes actually read.

The implementation given by this pull request redefines the `read` function as a wrapper around the `readinto` function, first creating the necessary buffer.
