### PR TITLE
Removed unnecessary length argument to util.get_string

### DIFF
--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -113,8 +113,8 @@ class ControlTest(unittest.TestCase):
     def test_get_string(self):
         manufacturer_str = 'Travis Robinson'.encode('utf-16-le').decode('utf-16-le')
         product_str = 'Benchmark Device'.encode('utf-16-le').decode('utf-16-le')
-        self.assertEqual(usb.util.get_string(self.dev, len(manufacturer_str), self.dev.iManufacturer), manufacturer_str)
-        self.assertEqual(usb.util.get_string(self.dev, len(product_str), self.dev.iProduct), product_str)
+        self.assertEqual(usb.util.get_string(self.dev, self.dev.iManufacturer), manufacturer_str)
+        self.assertEqual(usb.util.get_string(self.dev, self.dev.iProduct), product_str)
 
 def get_suite():
     suite = unittest.TestSuite()

--- a/usb/legacy.py
+++ b/usb/legacy.py
@@ -270,11 +270,11 @@ class DeviceHandle(object):
 
         Arguments:
             index: index of descriptor in the device.
-            length: number of bytes of the string
+            length: number of bytes of the string (ignored)
             langid: Language ID. If it is omittedi, will be
                     used the first language.
         """
-        return util.get_string(self.dev, length, index, langid).encode('ascii')
+        return util.get_string(self.dev, index, langid).encode('ascii')
 
     def getDescriptor(self, desc_type, desc_index, length, endpoint = -1):
         r"""Retrieves a descriptor from the device identified by the type

--- a/usb/util.py
+++ b/usb/util.py
@@ -218,13 +218,11 @@ def dispose_resources(device):
     """
     device._ctx.dispose(device)
 
-def get_string(dev, length, index, langid = None):
+def get_string(dev, index, langid = None):
     r"""Retrieve a string descriptor from the device.
 
     dev is the Device object to which the request will be
     sent to.
-
-    length is the maximum length of the string in number of characters.
 
     index is the string descriptor index and langid is the Language
     ID of the descriptor. If langid is omitted, the string descriptor
@@ -252,7 +250,7 @@ def get_string(dev, length, index, langid = None):
 
     buf = get_descriptor(
                 dev,
-                length * 2 + 2, # string is utf16 + 2 bytes of the descriptor
+                255, # Maximum descriptor size
                 DESC_TYPE_STRING,
                 index,
                 langid


### PR DESCRIPTION
As discussed in pull request #33. I decided to drop the argument altogether since when one is running a python interpreter, 255 bytes are not really an issue.
