### PR TITLE
Add 'control' module to the list exported by usb package.

### DIFF
--- a/usb/__init__.py
+++ b/usb/__init__.py
@@ -48,7 +48,7 @@ version_info = (1, 0, 0, 'b2')
 __version__ = '%d.%d.%d%s' % version_info
 
 
-__all__ = ['legacy', 'core', 'backend', 'util', 'libloader']
+__all__ = ['legacy', 'control', 'core', 'backend', 'util', 'libloader']
 
 
 def _setup_log():


### PR DESCRIPTION
'control' was not in the **all** field for the 'usb' package. This means that
  from usb import *
  control.XXX
would fail to find the module 'control'.
