### PR TITLE
Expose 'extra' descriptors through core objects.

### DIFF
--- a/usb/backend/libusb0.py
+++ b/usb/backend/libusb0.py
@@ -401,7 +401,9 @@ class _LibUSB(usb.backend.IBackend):
     def get_configuration_descriptor(self, dev, config):
         if config >= dev.descriptor.bNumConfigurations:
             raise IndexError('Invalid configuration index ' + str(config))
-        return dev.config[config]
+        config_desc = dev.config[config]
+        config_desc.extra_descriptors = config_desc.extra[:config_desc.extralen]
+        return config_desc
 
     @methodtrace(_logger)
     def get_interface_descriptor(self, dev, intf, alt, config):
@@ -411,14 +413,18 @@ class _LibUSB(usb.backend.IBackend):
         interface = cfgdesc.interface[intf]
         if alt >= interface.num_altsetting:
             raise IndexError('Invalid alternate setting index ' + str(alt))
-        return interface.altsetting[alt]
+        intf_desc = interface.altsetting[alt]
+        intf_desc.extra_descriptors = intf_desc.extra[:intf_desc.extralen]
+        return intf_desc
 
     @methodtrace(_logger)
     def get_endpoint_descriptor(self, dev, ep, intf, alt, config):
         interface = self.get_interface_descriptor(dev, intf, alt, config)
         if ep >= interface.bNumEndpoints:
             raise IndexError('Invalid endpoint index ' + str(ep))
-        return interface.endpoint[ep]
+        ep_desc = interface.endpoint[ep]
+        ep_desc.extra_descriptors = ep_desc.extra[:ep_desc.extralen]
+        return ep_desc
 
     @methodtrace(_logger)
     def open_device(self, dev):

--- a/usb/backend/openusb.py
+++ b/usb/backend/openusb.py
@@ -571,6 +571,7 @@ class _OpenUSB(usb.backend.IBackend):
                                               0,
                                               config,
                                               byref(desc)))
+        desc.extra_descriptors = None
         return desc
 
     @methodtrace(_logger)
@@ -584,6 +585,7 @@ class _OpenUSB(usb.backend.IBackend):
                                                  intf,
                                                  alt,
                                                  byref(desc)))
+        desc.extra_descriptors = None
         return desc
 
     @methodtrace(_logger)
@@ -598,6 +600,7 @@ class _OpenUSB(usb.backend.IBackend):
                                                 alt,
                                                 ep,
                                                 byref(desc)))
+        desc.extra_descriptors = None
         return desc
 
     @methodtrace(_logger)

--- a/usb/core.py
+++ b/usb/core.py
@@ -266,7 +266,8 @@ class Endpoint(object):
                     'wMaxPacketSize',
                     'bInterval',
                     'bRefresh',
-                    'bSynchAddress'
+                    'bSynchAddress',
+                    'extra_descriptors'
                 )
             )
 
@@ -358,6 +359,7 @@ class Interface(object):
                     'bInterfaceSubClass',
                     'bInterfaceProtocol',
                     'iInterface',
+                    'extra_descriptors'
                 )
             )
 
@@ -432,7 +434,8 @@ class Configuration(object):
                     'bConfigurationValue',
                     'iConfiguration',
                     'bmAttributes',
-                    'bMaxPower'
+                    'bMaxPower',
+                    'extra_descriptors'
                 )
             )
 


### PR DESCRIPTION
libusb providers a flat byte array containing all unparsed descriptors under a
configuration, interface and end-point. Expose this array as a python list so
clients can parse the descriptors themselves.
