### PR TITLE
Typo fix: libusb1.py LIBUSB_SUCESS -> LIBUSB_SUCCESS

### DIFF
--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -29,7 +29,7 @@ __author__ = 'Wander Lairson Costa'
 
 __all__ = [
             'get_backend',
-            'LIBUSB_SUCESS',
+            'LIBUSB_SUCCESS',
             'LIBUSB_ERROR_IO',
             'LIBUSB_ERROR_INVALID_PARAM',
             'LIBUSB_ERROR_ACCESS',


### PR DESCRIPTION
Fix incorrectly exposed constant `LIBUSB_SUCESS` in `libusb1.py` backend.