### PR TITLE
Add missing comma in string list

### DIFF
--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -42,14 +42,14 @@ __all__ = [
             'LIBUSB_ERROR_INTERRUPTED',
             'LIBUSB_ERROR_NO_MEM',
             'LIBUSB_ERROR_NOT_SUPPORTED',
-            'LIBUSB_ERROR_OTHER'
+            'LIBUSB_ERROR_OTHER',
             'LIBUSB_TRANSFER_COMPLETED',
             'LIBUSB_TRANSFER_ERROR',
             'LIBUSB_TRANSFER_TIMED_OUT',
             'LIBUSB_TRANSFER_CANCELLED',
             'LIBUSB_TRANSFER_STALL',
             'LIBUSB_TRANSFER_NO_DEVICE',
-            'LIBUSB_TRANSFER_OVERFLOW'
+            'LIBUSB_TRANSFER_OVERFLOW',
         ]
 
 _logger = logging.getLogger('usb.backend.libusb1')


### PR DESCRIPTION
In Python, two adjacent strings get concatenated implicitely.
Missing commas in multi-line string lists is a common source of bugs
causing unwanted string concatenation. In this case, it is clear that this
comma is missing by mistake and there should not be a concatenation.

I also add a comma on the last item for consistency.