### PR TITLE
Don't call libusb_exit on a null pointer

### DIFF
--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -701,7 +701,8 @@ class _LibUSB(usb.backend.IBackend):
 
     @methodtrace(_logger)
     def _finalize_object(self):
-        self.lib.libusb_exit(self.ctx)
+        if self.ctx:
+            self.lib.libusb_exit(self.ctx)
 
 
     @methodtrace(_logger)


### PR DESCRIPTION
If `libusb_init` throws an exception, then `ctx` is null here