### PR TITLE
Termux (Android support), usb device from sys device (file descriptor), Issue #285

### DIFF
--- a/tools/termux_device_info.py
+++ b/tools/termux_device_info.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""\
+Run in Termux on Android. Prints device infos for selected device.
+
+See: https://wiki.termux.com/wiki/Termux-usb
+
+Call script in Termux like this:
+    termux-usb -r -e ./tools/termux_device_info.py /dev/bus/usb/001/002
+
+With /dev/bus/usb/001/002 being the correct device path as returned
+by `termux-usb -l`.
+
+If using a virtual environment then call the python script from
+inside a bash script wrapper:
+
+    #!/bin/bash
+    source /path/to/venv/bin/activate
+    python script.py "$@"
+    deactivate
+
+"""
+
+from __future__ import print_function
+
+import usb.core
+
+
+def main(fd):
+    device = usb.core.device_from_fd(fd)
+    print(device)
+
+
+if __name__ == "__main__":
+    # grab fd number from args
+    #   (from termux wrapper)
+    import sys
+
+    fd = int(sys.argv[1])
+    main(fd)

--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -310,11 +310,24 @@ def _setup_prototypes(lib):
     # void libusb_unref_device(libusb_device *dev)
     lib.libusb_unref_device.argtypes = [c_void_p]
 
+    # int libusb_wrap_sys_device(libusb_context *ctx,
+    #                            intptr_t sys_dev,
+    #                            libusb_device_handle **dev_handle)
+    lib.libusb_wrap_sys_device.argtypes = [
+            c_void_p,
+            c_int,
+            POINTER(_libusb_device_handle)
+        ]
+
     # int libusb_open(libusb_device *dev, libusb_device_handle **handle)
     lib.libusb_open.argtypes = [c_void_p, POINTER(_libusb_device_handle)]
 
     # void libusb_close(libusb_device_handle *dev_handle)
     lib.libusb_close.argtypes = [_libusb_device_handle]
+
+    # libusb_device * libusb_get_device(libusb_device_handle *devh)
+    lib.libusb_get_device.argtypes = [c_void_p]
+    lib.libusb_get_device.restype = _libusb_device_handle
 
     # int libusb_set_configuration(libusb_device_handle *dev,
     #                              int configuration)

--- a/usb/core.py
+++ b/usb/core.py
@@ -1289,3 +1289,18 @@ def show_devices(verbose=False, **kwargs):
             strings += "%s\n\n" % str(device)
 
     return _DescriptorInfo(strings)
+
+def device_from_fd(fd):
+    import usb.backend.libusb1 as libusb1
+
+    backend = libusb1.get_backend()
+    if not backend:
+        raise NoBackendError('No backend available')
+
+    dev = backend.get_device_from_fd(fd)
+
+    # create device
+    device = Device(dev, backend)
+    device._ctx.handle = dev
+
+    return device


### PR DESCRIPTION
See Issue #285 .

Not sure how to implement tests for this.
Resources are released automatically from system by Android. On *nix, too?