### PR TITLE
[WIP] Begin implementation of asynchronous transfers

### DIFF
--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -512,6 +512,30 @@ def _setup_prototypes(lib):
     lib.libusb_get_max_iso_packet_size.argtypes = [c_void_p,
                                                    c_ubyte]
 
+    # void libusb_fill_bulk_transfer(
+    #               libusb_transfer* transfer
+    #               libusb_device_handle* dev_handle
+    #               char endpoint
+    #               char* buffer
+    #               int length
+    #               libusb_transfer_cb_fn callback
+    #               void* user_data
+    #               uint timeout
+    #           );
+    def libusb_fill_bulk_transfer(_libusb_transfer_p, dev_handle, endpoint,
+                                  buffer, length, callback, user_data, timeout):
+        r"""This function is extremely dangerous, so we must deal with it."""
+        transfer = _libusb_transfer_p.contents
+        transfer.dev_handle = dev_handle
+        transfer.endpoint = endpoint
+        transfer.type = _LIBUSB_TRANSFER_TYPE_BULK
+        transfer.timeout = timeout
+        transfer.buffer = cast(buffer, c_void_p)
+        transfer.length = length
+        transfer.user_data = user_data
+        transfer.callback = callback
+    lib.libusb_fill_bulk_transfer = libusb_fill_bulk_transfer
+
     # void libusb_fill_iso_transfer(
     #               struct libusb_transfer* transfer,
     #               libusb_device_handle*  dev_handle,

--- a/usb/backend/libusb1.py
+++ b/usb/backend/libusb1.py
@@ -536,6 +536,30 @@ def _setup_prototypes(lib):
         transfer.callback = callback
     lib.libusb_fill_bulk_transfer = libusb_fill_bulk_transfer
 
+    # void libusb_fill_interrupt_transfer(
+    #               struct libusb_transfer* transfer,
+    #               libusb_device_handle* dev_handle,
+    #               unsigned char endpoint,
+    #               unsigned char* buffer,
+    #               int length,
+    #               libusb_transfer_cb_fn callback,
+    #               void* user_data,
+    #               unsigned int timeout
+    #           );
+    def libusb_fill_interrupt_transfer(_libusb_transfer_p, dev_handle, endpoint,
+                                  buffer, length, callback, user_data, timeout):
+        r"""This function is extremely dangerous, so we must deal with it."""
+        transfer = _libusb_transfer_p.contents
+        transfer.dev_handle = dev_handle
+        transfer.endpoint = endpoint
+        transfer.type = _LIBUSB_TRANSFER_TYPE_INTERRUPT
+        transfer.timeout = timeout
+        transfer.buffer = cast(buffer, c_void_p)
+        transfer.length = length
+        transfer.user_data = user_data
+        transfer.callback = callback
+    lib.libusb_fill_interrupt_transfer = libusb_fill_interrupt_transfer
+
     # void libusb_fill_iso_transfer(
     #               struct libusb_transfer* transfer,
     #               libusb_device_handle*  dev_handle,

--- a/usb/core.py
+++ b/usb/core.py
@@ -1028,6 +1028,50 @@ class Device(_objfinalizer.AutoFinalizedObject):
         else:
             return buff
 
+    def submit_read(self, endpoint, size_or_buffer, timeout = None):
+        backend = self._ctx.backend
+
+        fn_map = {
+                    util.ENDPOINT_TYPE_BULK:backend.submit_bulk_read,
+                    util.ENDPOINT_TYPE_INTR:backend.submit_intr_read,
+                    #util.ENDPOINT_TYPE_ISO:backend.submit_iso_read
+                }
+
+        intf, ep = self._ctx.setup_request(self, endpoint)
+        fn = fn_map[util.endpoint_type(ep.bmAttributes)]
+
+        if isinstance(size_or_buffer, array.array):
+            buff = size_or_buffer
+        else:
+            buff = util.create_buffer(size_or_buffer)
+
+        return fn(
+                self._ctx.handle,
+                ep.bEndpointAddress,
+                intf.bInterfaceNumber,
+                buff,
+                self.__get_timeout(timeout))
+
+    def submit_write(self, endpoint, data, timeout = None):
+        backend = self._ctx.backend
+
+        fn_map = {
+                    util.ENDPOINT_TYPE_BULK:backend.submit_bulk_write,
+                    #util.ENDPOINT_TYPE_INTR:backend.intr_write,
+                    #util.ENDPOINT_TYPE_ISO:backend.iso_write
+                }
+
+        intf, ep = self._ctx.setup_request(self, endpoint)
+        fn = fn_map[util.endpoint_type(ep.bmAttributes)]
+
+        return fn(
+                self._ctx.handle,
+                ep.bEndpointAddress,
+                intf.bInterfaceNumber,
+                _interop.as_array(data),
+                self.__get_timeout(timeout)
+            )
+
     def ctrl_transfer(self, bmRequestType, bRequest, wValue=0, wIndex=0,
             data_or_wLength = None, timeout = None):
         r"""Do a control transfer on the endpoint 0.


### PR DESCRIPTION
The purpose of these patches is to allow asynchronous USB transfers. Keep in mind that I am not claiming this should be the final form. I'm not an asyncio expert, and I am open for suggestions on how to improve the implementation. Note that async transfers are only imlemented for the libusb1 backend.
I am striving to achieve an API that looks like the following example:

	async def do_usb_stuff():
	    dev = usb.core.find(...)
	
	    transfer1 = dev.submit_read(...)
	    transfer2 = dev.submit_write(...)
	
	    await transfer2.result()
	    await transfer1.result()

Note that this is symmetrical to the sync functions, in that the transfer type does not have to be specified. It is derived from the endpoint.

await transfer.result() is similar to an asyncio.Future, although the implementation is not exactly an awaitable future. This is an implementation detail, and it could be changed if needed.