### PR TITLE
Use setuptools_scm for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ MANIFEST
 dist
 .tox
 *.egg-info
+usb/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.rst
+
+[options]
+setup_requires = setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,12 @@
 
 
 from setuptools import setup
+from distutils.version import LooseVersion
+from setuptools import __version__ as setuptools_version
 
+setuptools_scm = 'setuptools_scm'
+if LooseVersion(setuptools_version).version[0] < 12:
+    setuptools_scm += '<2.0'
 
 setup(
     name='pyusb',
@@ -39,6 +44,7 @@ setup(
         "version_scheme": "post-release",
         "write_to": "usb/_version.py",
     },
+    setup_requires=setuptools_scm,
     description='Python USB access module',
     author='Robert Wlodarczyk',
     author_email='robert@simplicityguy.com',

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,13 @@
 
 from setuptools import setup
 
-import usb
-
 
 setup(
     name='pyusb',
-    version=usb.__version__,
+    use_scm_version={
+        "version_scheme": "post-release",
+        "write_to": "usb/_version.py",
+    },
     description='Python USB access module',
     author='Robert Wlodarczyk',
     author_email='robert@simplicityguy.com',

--- a/usb/__init__.py
+++ b/usb/__init__.py
@@ -48,8 +48,19 @@ import os
 __author__ = 'Wander Lairson Costa'
 
 # Use Semantic Versioning, http://semver.org/
-version_info = (1, 0, 2)
-__version__ = '%d.%d.%d' % version_info
+try:
+    from usb._version import version as __version__
+except ImportError:
+    __version__ = '0.0.0'
+
+def _get_version_info(version):
+    import re
+    m = re.match(r'(\d+)\.(\d+)\.(\d+)[.-]?(\D.*)?', version)
+    return tuple(
+        int(v) if v.isdigit() else v for v in m.groups() if v
+    )
+
+version_info = _get_version_info(__version__)
 
 __all__ = ['legacy', 'control', 'core', 'backend', 'util', 'libloader']
 

--- a/usb/__init__.py
+++ b/usb/__init__.py
@@ -53,14 +53,14 @@ try:
 except ImportError:
     __version__ = '0.0.0'
 
-def _get_version_info(version):
+def _get_extended_version_info(version):
     import re
-    m = re.match(r'(\d+)\.(\d+)\.(\d+)[.-]?(\D.*)?', version)
-    return tuple(
-        int(v) if v.isdigit() else v for v in m.groups() if v
-    )
+    m = re.match(r'(\d+)\.(\d+)\.(\d+)[.-]?(.*|\b)', version)
+    major, minor, patch, suffix = m.groups()
+    return int(major), int(minor), int(patch), suffix
 
-version_info = _get_version_info(__version__)
+extended_version_info = _get_extended_version_info(__version__)
+version_info = extended_version_info[:3]
 
 __all__ = ['legacy', 'control', 'core', 'backend', 'util', 'libloader']
 

--- a/usb/__init__.py
+++ b/usb/__init__.py
@@ -55,7 +55,7 @@ except ImportError:
 
 def _get_extended_version_info(version):
     import re
-    m = re.match(r'(\d+)\.(\d+)\.(\d+)[.-]?(.*|\b)', version)
+    m = re.match(r'(\d+)\.(\d+)\.(\d+)[.-]?(.*)', version)
     major, minor, patch, suffix = m.groups()
     return int(major), int(minor), int(patch), suffix
 


### PR DESCRIPTION
Automatically generates the `usb.__version__` string on installation.
Would close pyusb/pyusb#298.

**This PR adds `setuptools_scm` to automatically generate version strings on install.**

There's still a few things to be considered before this should be merged:
- what are the target python versions and OSes? (Let's create a list here and I can work my way through all of them to see if packaging won't fail due to old setuptools versions)
- I set the setuptools_scm `version_scheme` to **post-release** which generates version strings like `1.0.2.post42+SHORTGITHASH` (42 commits after tag '1.0.2') instead of the default which would increase the micro version and create `1.0.3.dev42+SHORTGITHASH`, but that's just personal preference I guess. (see [here](https://github.com/pypa/setuptools_scm#version-number-construction))
- I set the fallback version to `0.0.0` in case something went wrong with loading `usb/_version.py`. The only scenario I can come up with in which this should happen is, if someone clones the repo and imports pyusb from the repository root without installing (this is the default when running the tests manually right now).
- the `usb.version_info` tuple is generated from the version string and supports the tag format that's already used in the repository. So for example:
  ```
  # git tag: v1.0.0
  __version__ = "1.0.0"
  version_info = (1, 0, 0)

  # git tag: v1.0.0rc1
  __version__ = "1.0.0rc1"
  version_info = (1, 0, 0, 'rc1')

  # one commit newer than tag v1.0.0
  __version__ = "1.0.0.post1+ace0f2e4"
  version_info = (1, 0, 0, 'post1+ace0f2e4')

  # one commit newer than tag v1.0.0 AND repository has uncommited changes
  __version__ = "1.0.0.post1+ace0f2e4.d20200609"
  version_info = (1, 0, 0, 'post1+ace0f2e4.d20200609')
  ```

I also tried to introduce as few changes as possible.
Happy to get some feedback on the PR and to discuss the mentioned points above.

Cheers,
Andreas :smiley: 


