### PR TITLE
run tests via tox and github actions

### DIFF
--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -1,0 +1,26 @@
+name: pyusb
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      max-parallel: 4
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -15,12 +15,15 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install setuptools>=30.3.0 tox
+    - id: pyver2toxenv
+      run: |
+        python -c "import sys; print('::set-output name=toxenv::py' + sys.argv[1].replace('.', ''))" ${{ matrix.python-version }}
     - name: Test with tox
-      run: tox
+      run: tox -e ${{ steps.pyver2toxenv.outputs.toxenv }}

--- a/tox.ini
+++ b/tox.ini
@@ -2,15 +2,6 @@
 envlist = py{27,35,36,37,38}
 requires =
     setuptools >= 30.3.0
-    tox-gh-actions
-
-[gh-actions]
-python =
-    2.7: py27
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38
 
 [testenv]
 changedir=tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,17 @@
-# Tox is broken with Python 2.4
-# setuptools is broken with Python 2.5
-# pythonz is broken with Python 3.0
-# Pip 1.5.4 (distributed with Ubuntu 14.04) is broken with Python 3.1
 [tox]
-envlist = py26,py27,py32,py33,py34
+envlist = py{27,35,36,37,38}
+requires =
+    setuptools >= 30.3.0
+    tox-gh-actions
+
+[gh-actions]
+python =
+    2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
 
 [testenv]
 changedir=tests
 commands=python testall.py
-
-[testenv:py24]
-basepython = {homedir}/.pythonz/pythons/CPython-2.4.6/bin/python
-
-[testenv:py25]
-basepython = {homedir}/.pythonz/pythons/CPython-2.5.6/bin/python
-
-[testenv:py26]
-basepython = {homedir}/.pythonz/pythons/CPython-2.6.9/bin/python
-
-[testenv:py27]
-basepython = {homedir}/.pythonz/pythons/CPython-2.7.8/bin/python
-
-[testenv:py30]
-basepython = {homedir}/.pythonz/pythons/CPython-3.0.1/bin/python
-
-[testenv:py31]
-basepython = {homedir}/.pythonz/pythons/CPython-3.1.5/bin/python
-
-[testenv:py32]
-basepython = {homedir}/.pythonz/pythons/CPython-3.2.5/bin/python
-
-[testenv:py33]
-basepython = {homedir}/.pythonz/pythons/CPython-3.3.5/bin/python
-
-[testenv:py34]
-basepython = {homedir}/.pythonz/pythons/CPython-3.4.1/bin/python


### PR DESCRIPTION
This PR adds a github action workflow to run the tests for python 2.7, 3.5, 3.6, 3.7, 3.8 on windows, linux and macos via tox.

Currently windows-py27 fails due to an ImportError (fix: https://github.com/ap--/pyusb/commit/5ece7fa23597d99abcb62df413ef9d22fcbf3f0d) and all windows tests throw warnings because no backend can be imported.

Since tox runs `python setup.py sdist` to install the package in the test environment, this could be used to verify that `setuptools_scm`'s version is correctly included.

Cheers :smiley: 
Andreas