### PR TITLE
tests: minimal changeset for pytest support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ description-file = README.rst
 
 [options]
 setup_requires = setuptools_scm
+
+[tool:pytest]
+addopts = -v

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -40,6 +40,7 @@ import time
 import sys
 
 class BackendTest(unittest.TestCase):
+    __test__ = False
     @methodtrace(utils.logger)
     def __init__(self, backend):
         unittest.TestCase.__init__(self)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -41,6 +41,7 @@ from usb._debug import methodtrace
 import sys
 
 class ControlTest(unittest.TestCase):
+    __test__ = False
     @methodtrace(utils.logger)
     def __init__(self, dev):
         unittest.TestCase.__init__(self)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -52,6 +52,7 @@ def make_data_list(length = 8):
             utils.get_str_data1(length))
 
 class DeviceTest(unittest.TestCase):
+    __test__ = False
     @methodtrace(utils.logger)
     def __init__(self, dev):
         unittest.TestCase.__init__(self)
@@ -268,6 +269,7 @@ class DeviceTest(unittest.TestCase):
         self.dev.clear_halt(0x81)
 
 class ConfigurationTest(unittest.TestCase):
+    __test__ = False
     @methodtrace(utils.logger)
     def __init__(self, dev):
         unittest.TestCase.__init__(self)
@@ -297,6 +299,7 @@ class ConfigurationTest(unittest.TestCase):
         self.cfg.set()
 
 class InterfaceTest(unittest.TestCase):
+    __test__ = False
     @methodtrace(utils.logger)
     def __init__(self, dev):
         unittest.TestCase.__init__(self)
@@ -329,6 +332,7 @@ class InterfaceTest(unittest.TestCase):
         self.intf.set_altsetting()
 
 class EndpointTest(unittest.TestCase):
+    __test__ = False
     @methodtrace(utils.logger)
     def __init__(self, dev):
         unittest.TestCase.__init__(self)

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -37,6 +37,7 @@ import usb.core
 from usb._debug import methodtrace
 
 class LegacyTest(unittest.TestCase):
+    __test__ = False
     @methodtrace(utils.logger)
     def __init__(self):
         unittest.TestCase.__init__(self)


### PR DESCRIPTION
This PR allows running the testsuite with pytest without errors. It's a fix for #319 

<br>

With the current unittest testsuite, only 7 tests are run that do not require the hardware test device referenced in tests/devinfo.py `(ID_VENDOR = 0x04d8, ID_PRODUCT = 0xfa2e)`. When pytest is run, it autodiscovers all `unittest.TestCase` subclasses and tries to run them. This has issues because the TestCase subclasses do not use setup and teardown consistently and have some non-independent test. So for implementing support for pytest, there's basically three options to consider:

#### 1. add pytest support for the 7 tests that do not require the hardware device, keep unittest functionality intact

This is the easiest option, and it's implemented in this PR. It simply ignores the TestCases that require the test hardware, and so when you run pytest in the project root folder, the 7 tests that do not rely on the device present are run and pass.

#### 2. add pytest support for all tests and keep unittest functionality intact

This is the most complicated option. I implemented it here [ap--/pyusb/commit/855c3436](https://github.com/ap--/pyusb/commit/855c3436fd438f1bb1eaea69c2ee82076476419c) but of course can't fully test if it's working because i am lacking the test hardware. To keep unittest functionality as-is and intact, it requires to do a few workarounds to allow actually parameterizing tests in pytest (for testing different backends, etc). I believe that just for the sake of having all those tests show up as skipped anyways (because the users wont have the testdevice), it's not worth including this complexity compared to solution 1

#### 3. move to pytest drop unittest and rewrite all tests

I think this would be the cleanest option. It could be worth considering to do this together with dropping python 2 support in the future. To increase code coverage (currently with the 7 tests at 46%) it might also be beneficial to create a mocked software USB test device that would allow to test most of the pyusb wrapper code. (But this is potentially also a lot of work). Or the tests could maybe be rewritten against hardware that most people have available anyways.


<br><br>

Given the above options I think 1 is the most pragmatic for now, because it allows people to type `pytest` in their repository checkout and it won't throw an error. And once more legacy code is dropped I'd be happy to help tackling option 3. Let me know what you think 😊 


Cheers,
Andreas 😃  