### PR TITLE
[_interop.py] Migrate to 3.9 compatibility.

### DIFF
--- a/usb/_interop.py
+++ b/usb/_interop.py
@@ -96,5 +96,8 @@ def as_array(data=None):
         # When you pass a unicode string or a character sequence,
         # you get a TypeError if the first parameter does not match
         a = array.array('B')
-        a.fromstring(data) # deprecated since 3.2
+        try:
+            a.fromstring(data)
+        except AttributeError:
+            a.frombytes(data.encode())
         return a


### PR DESCRIPTION
https://bugs.python.org/issue38916

For version 3.9 `fromstring` is no longer supported and will return an
`AttributeError`.

This adds a backwards compatible way to do the same thing as before by
using the `frombytes` function.

This works with python 3.8, 2.7, and 3.9 from manual testing.