### PR TITLE
docs: fix simple typo, respectivelly -> respectively

### DIFF
--- a/usb/backend/__init__.py
+++ b/usb/backend/__init__.py
@@ -211,7 +211,7 @@ class IBackend(_objfinalizer.AutoFinalizedObject):
 
         This method should only be called when the interface has more than
         one alternate setting. The dev_handle is the value returned by the
-        open_device() method. intf and altsetting are respectivelly the
+        open_device() method. intf and altsetting are respectively the
         bInterfaceNumber and bAlternateSetting fields of the related interface.
         """
         _not_implemented(self.set_interface_altsetting)


### PR DESCRIPTION
There is a small typo in usb/backend/__init__.py.

Should read `respectively` rather than `respectivelly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md