### PR TITLE
set_interface: Raise ValueError if no match is found

### DIFF
--- a/usb/core.py
+++ b/usb/core.py
@@ -206,6 +206,8 @@ class _ResourceManager(object):
                 i = util.find_descriptor(cfg, bInterfaceNumber=intf, bAlternateSetting=alt)
             else:
                 i = util.find_descriptor(cfg, bInterfaceNumber=intf)
+            if i is None:
+                raise ValueError('No matching interface (' + str(intf) + ',' + str(alt) + ')')
 
         self.managed_claim_interface(device, i)
 


### PR DESCRIPTION
Otherwise the type check for claim_interface will fail and the
error message is less helpful.

Signed-off-by: Tormod Volden <debian.tormod@gmail.com>

BEFORE:

```
>>> dev.set_interface_altsetting(0, 1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyusb/usb/core.py", line 936, in set_interface_altsetting
    self._ctx.managed_set_interface(self, interface, alternate_setting)
  File "pyusb/usb/core.py", line 113, in wrapper
    return f(self, *args, **kwargs)
  File "pyusb/usb/core.py", line 210, in managed_set_interface
    self.managed_claim_interface(device, i)
  File "pyusb/usb/core.py", line 113, in wrapper
    return f(self, *args, **kwargs)
  File "pyusb/usb/core.py", line 178, in managed_claim_interface
    self.backend.claim_interface(self.handle, i)
  File "pyusb/usb/backend/libusb1.py", line 829, in claim_interface
    _check(self.lib.libusb_claim_interface(dev_handle.handle, intf))
ctypes.ArgumentError: argument 2: <class 'TypeError'>: wrong type
```

AFTER:

```
...
ValueError: No matching interface (0,1)
```