### PR TITLE
Stop further releasing to Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ Python >= 3.6, ctypes and a pre-built USB backend library
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Hardware :: Hardware Drivers'
-    ]
+    ],
+    python_requires='>=3.6.0'
 )
 


### PR DESCRIPTION
Related to #363 
This PR probably stops further releasing (> v1.1.1) to Python 2.
I just copied https://github.com/chainer/chainer/pull/8517 and am not sure if this really works.
Please check carefully.