### PR TITLE
Make Device hashable again

### DIFF
--- a/usb/core.py
+++ b/usb/core.py
@@ -746,6 +746,9 @@ class Device(_objfinalizer.AutoFinalizedObject):
         else:
             return NotImplemented
 
+    def __hash__(self):
+        return hash((self.backend, self.bus, self.address))
+
     def __repr__(self):
         return "<" + self._str() + ">"
 


### PR DESCRIPTION
Commit 251dbc15df00b5 (core: implement `Device.__eq__`") had the side effect of making `Device` objects unhashable, so they could no longer be included in a `set()`.  This was a regression from v1.1.1.  Add a corresponding `__hash__()` method so that Device objects are hashable again.

Fixes eblot/pyftdi#256