### PR TITLE
Fix the setuptools underscore warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 [options]
 setup_requires = setuptools_scm


### PR DESCRIPTION
Fix the following warning:

    /usr/lib/python3.10/site-packages/setuptools/dist.py:697: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead