### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,9 @@ setup(
     author='Jonas Malaco',
     author_email='me@jonasmalaco.com',
     url='https://pyusb.github.io/pyusb',
+    project_urls={
+        'Source': 'https://github.com/pyusb/pyusb',
+    },
     packages=['usb', 'usb.backend'],
     long_description=
 """


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)