### PR TITLE
Loads libusb dll from the working directory

### DIFF
--- a/usb/libloader.py
+++ b/usb/libloader.py
@@ -94,13 +94,18 @@ def locate_library (candidates, find_library=ctypes.util.find_library):
         # Workaround for CPython 3.3 issue#16283 / pyusb #14
         if use_dll_workaround:
             candidate += '.dll'
-            libpath = lambda p: os.path.abspath(p)
-        else:
-            libpath = lambda p: p
 
         libname = find_library(candidate)
         if libname:
-            return libpath(libname)
+            return libname
+
+        # If the library isn't found in the system path
+        # looks for it in the working directory
+        if use_dll_workaround:
+            candidate = os.path.abspath(candidate)
+            libname = find_library(candidate)
+            if libname:
+                return libname
     # -- end for
     return None
 

--- a/usb/libloader.py
+++ b/usb/libloader.py
@@ -67,7 +67,7 @@ class LibraryMissingSymbolsException(LibraryException):
     pass
 
 
-def locate_library (candidates, find_library=None):
+def locate_library (candidates, find_library=ctypes.util.find_library):
     """Tries to locate a library listed in candidates using the given
     find_library() function (or ctypes.util.find_library).
     Returns the first library found, which can be the library's name

--- a/usb/libloader.py
+++ b/usb/libloader.py
@@ -33,6 +33,7 @@
 import ctypes
 import ctypes.util
 import logging
+import os
 import sys
 
 __all__ = [
@@ -66,7 +67,7 @@ class LibraryMissingSymbolsException(LibraryException):
     pass
 
 
-def locate_library (candidates, find_library=ctypes.util.find_library):
+def locate_library (candidates, find_library=None):
     """Tries to locate a library listed in candidates using the given
     find_library() function (or ctypes.util.find_library).
     Returns the first library found, which can be the library's name
@@ -93,10 +94,13 @@ def locate_library (candidates, find_library=ctypes.util.find_library):
         # Workaround for CPython 3.3 issue#16283 / pyusb #14
         if use_dll_workaround:
             candidate += '.dll'
+            libpath = lambda p: os.path.abspath(p)
+        else:
+            libpath = lambda p: p
 
         libname = find_library(candidate)
         if libname:
-            return libname
+            return libpath(libname)
     # -- end for
     return None
 


### PR DESCRIPTION
Hello,
while working on a cross plaftorm app I had some issues trying to run PyUSB on Windows, because I tried to avoid installing libusb binaries in system32.
Linux comes with libusb preinstalled and on macOS if I put the dylib installed with Homebrew in the working directory it PyUSB runs fine.
These changes allow PyUSB to use a libusb dll placed in the working directory on Windows , just like in macOS