### PR TITLE
legacy: Fix `DeviceHandle` finalizer checking for the wrong attribute

### DIFF
--- a/usb/legacy.py
+++ b/usb/legacy.py
@@ -143,7 +143,7 @@ class DeviceHandle(_objfinalizer.AutoFinalizedObject):
         self.__claimed_interface = None
 
     def _finalize_object(self):
-        if hasattr(self, 'self.dev') and self.dev:
+        if hasattr(self, 'dev') and self.dev:
             util.dispose_resources(self.dev)
             self.dev = None
 


### PR DESCRIPTION
Introduced in https://github.com/pyusb/pyusb/commit/e658484a03af0e8b3733105c67fe23d76232fc03. I believe this is a typo.

`hasattr(self, 'self.dev')` will never evaluate to `True` so `_finalize_object` will never actually run.