### PR TITLE
Search in default homebrew prefix on Apple Silicon

### DIFF
--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -22,11 +22,15 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools>=30.3.0 tox
     - name: Install libusb-1.0 (Windows)
-      if: matrix.platform == 'windows-latest'
+      if: startsWith(matrix.platform, 'windows-')
       shell: pwsh
       run: |
         Invoke-WebRequest -Uri https://github.com/libusb/libusb/releases/download/v1.0.24/libusb-1.0.24.7z -OutFile libusb-1.0.24.7z
         7z e libusb-1.0.24.7z -oC:\Windows\System32 VS2019/MS64/dll/libusb-1.0.dll
+    - name: Install libusb-1.0 (macos)
+      if: startsWith(matrix.platform, 'macos-')
+      run: |
+        brew install libusb
     - id: pyver2toxenv
       run: |
         python -c "import sys; print('::set-output name=toxenv::py' + sys.argv[1].replace('.', ''))" ${{ matrix.python-version }}

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -8,13 +8,13 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        platform: [ubuntu-latest, macos-14, macos-12, windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python dependencies

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Requirements and platform support
 ---------------------------------
 
 PyUSB is primarily developed and tested on Linux and Windows, but it should
-also work fine on any platform running Python >= 3.7, ctypes and at least one
+also work fine on any platform running Python >= 3.8, ctypes and at least one
 of the built-in backends.
 
 PyUSB supports `libusb 1.0`_, libusb 0.1 and OpenUSB. Of those, libusb 1.0 is

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -19,7 +19,7 @@ Platform neutrality:
     libusb 1.0, libusb 0.1 and OpenUSB.  You can write your own backend if you
     desire to.
 Portability:
-    PyUSB should run on any platform with Python >= 3.7, ctypes_ and at least
+    PyUSB should run on any platform with Python >= 3.8, ctypes_ and at least
     one of the supported builtin backends.
 Easiness:
     Communicating with an USB_ device has never been so easy! USB is a complex

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
 """
 PyUSB offers easy USB devices communication in Python.
 It should work without additional code in any environment with
-Python >= 3.7, ctypes and a pre-built USB backend library
+Python >= 3.8, ctypes and a pre-built USB backend library
 (currently: libusb 1.x, libusb 0.1.x or OpenUSB).
 """,
     classifiers=[
@@ -99,10 +99,11 @@ Python >= 3.7, ctypes and a pre-built USB backend library
         'Operating System :: POSIX :: BSD :: OpenBSD',
         'Operating System :: POSIX :: Linux',
         'Operating System :: POSIX :: SunOS/Solaris',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         # source(CPython,Jython,IronPython,PyPy): "The Long Term" section of
         # http://ojs.pythonpapers.org/index.php/tpp/article/viewFile/23/23
         'Programming Language :: Python :: Implementation :: CPython',
@@ -115,6 +116,6 @@ Python >= 3.7, ctypes and a pre-built USB backend library
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Hardware :: Hardware Drivers'
     ],
-    python_requires='>=3.7.0'
+    python_requires='>=3.8.0'
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310}
+envlist = py{38,39,310,311,312}
 requires =
     setuptools >= 30.3.0
 

--- a/usb/_interop.py
+++ b/usb/_interop.py
@@ -38,8 +38,8 @@ import array
 
 __all__ = []
 
-# we support Python >= 3.7
-assert sys.hexversion >= 0x030700f0
+# we support Python >= 3.8
+assert sys.hexversion >= 0x030800f0
 
 def as_array(data=None):
     """Convert loosely specified `data` to a byte array.

--- a/usb/libloader.py
+++ b/usb/libloader.py
@@ -181,6 +181,7 @@ def load_locate_library(candidates, cygwin_lib, name,
     elif candidates:
         lib = locate_library(candidates, find_library)
         if lib:
+            _LOGGER.debug("%r found as %s", (name or candidates), lib)
             if sys.platform == 'win32':
                 loaded_lib = load_library(lib, name, win_cls)
             else:


### PR DESCRIPTION
On Apple Silicon, homebrew will by default (and, really, it's the only recommended way to use it) use the `/opt/homebrew` prefix. The old `/usr/local` prefix is retained for the use of Intel/x86_64 homebrew.

This means that libraries (e.g. LibUSB) installed through homebrew on Apple Silicon will end up in `/opt/homebrew/lib/`. But that location isn't one of the search paths checked by `ctypes.util.find_library` (which is what we use if no custom `find_library` is supplied by the caller). Homebrew [patches](https://github.com/Homebrew/homebrew-core/blob/e91fb0c6e50a/Formula/p/python%403.11.rb#L196-L203) the Python interpreters they distribute, but other/stock interpreters don't know about this additional location for libraries.

As this is a frequent enough issue, let's check for that additional (and hardcoded) prefix if nothing is found in the normal search paths.

Note that, just like `ctypes.util.find_library`, we currently don't take into account the architecture: the first library found with a suitable name is used, even if it doesn't match the architecture of the Python interpreter in use.

This PR also includes basic maintenance (including bumping the minimum supported Python version), mostly just so it can run in our CI.

Related: #355
Related: #361
Related: #509
Related: https://github.com/liquidctl/liquidctl/pull/637#issuecomment-2081156293