### PR TITLE
When data_or_wLength is an array, keep the same object (alt fix)

### DIFF
--- a/usb/core.py
+++ b/usb/core.py
@@ -55,6 +55,7 @@ import logging
 import array
 import threading
 import functools
+import numbers
 
 _logger = logging.getLogger('usb.core')
 
@@ -1077,9 +1078,9 @@ class Device(_objfinalizer.AutoFinalizedObject):
         object which the data will be read to, and the return value is the
         number of bytes read.
         """
-        try:
+        if isinstance(data_or_wLength, numbers.Integral):
             buff = util.create_buffer(data_or_wLength)
-        except TypeError:
+        else:
             buff = _interop.as_array(data_or_wLength)
 
         self._ctx.managed_open()


### PR DESCRIPTION
Alt fix proposed in https://github.com/pyusb/pyusb/pull/527.

In `v1.2.1`, when data_or_wLength was an array, a `TypeError` exception was triggered in `create_buffer` which means `_interop.as_array` was called and the same array object was used (modified in-place as expected).

In  `v1.3.0`, commit 3ea79b01af08c1e8b2e0096a266c2cbd347738db introduced a change in `create_buffer` that does not trigger the `TypeError` exception and instead creates a new array from the one passed in `data_or_wLength`.

This means a new array is created and receives data for IN transfers, not the array passed as argument.