### PR TITLE
Add Additional Library Location for Snapcraft Support

### DIFF
--- a/usb/libloader.py
+++ b/usb/libloader.py
@@ -123,11 +123,9 @@ def locate_library(candidates, find_library=ctypes.util.find_library):
                 "x86_64-linux-gnu",
             ]
 
-            snap_root = os.environ.get("SNAP")
-
             for snap_architecture in snap_architectures:
                 snap_candidate = os.path.join(
-                    snap_root, "usr", "lib", snap_architecture, candidate + ".so.0"
+                    snap_env, "usr", "lib", snap_architecture, candidate + ".so.0"
                 )
                 if os.path.isfile(snap_candidate):
                     return snap_candidate


### PR DESCRIPTION
I have a project that is based on python-ecspos which depends on Pyusb. This project is built as a Snap which is then deployed onto an Ubuntu Core based system to communicate with a USB based receipt printer.

Libusb access is granted to a snap by specifying it as a stage-package in the ```snapcraft.yaml``` file per below example.

```
    stage-packages:
      - libusb-1.0-0
```

Libusb is then accessible via the path of ```$snap/usr/lib/{architecture}/libusb-1.0-0.so.0```. ```find_library``` currently does not find the backend and fails to access any USB device.

This patch adds a check if the PyUSB  is running as a SNAP, and if so, attempts to load the library from the $SNAP location.

This patch only caters to ```x86_64-linux-gnu``` architecture, though additional architectures can be added to the ```snap_architectures``` list.

